### PR TITLE
Keep zero usages and subset to max_sylls

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -1095,6 +1095,8 @@ def sort_syllables_by_stat_difference(complete_df, ctrl_group, exp_group, max_sy
     -------
     ordering (list): list of array indices for the new label mapping.
     '''
+    if max_sylls is not None:
+        complete_df = complete_df[complete_df.syllable < max_sylls]
 
     # Prepare DataFrame
     mutation_df = complete_df.groupby(['group', 'syllable']).mean()
@@ -1105,9 +1107,6 @@ def sort_syllables_by_stat_difference(complete_df, ctrl_group, exp_group, max_sy
 
     # compute mean difference at each syll usage and reorder based on difference
     ordering = (exp_df[stat] - control_df[stat]).sort_values(ascending=False).index
-
-    if max_sylls is not None:
-        ordering = ordering[:max_sylls]
 
     return list(ordering)
 
@@ -1127,14 +1126,13 @@ def sort_syllables_by_stat(complete_df, stat='usage', max_sylls=None):
     ordering (list): list of sorted syllables by stat.
     relabel_mapping (dict): a dict with key-value pairs {old_ordering: new_ordering}.
     '''
+    if max_sylls is not None:
+        complete_df = complete_df[complete_df.syllable < max_sylls]
 
     tmp = complete_df.groupby('syllable').mean().sort_values(by=stat, ascending=False).index
 
     # Get sorted ordering
     ordering = list(tmp)
-
-    if max_sylls is not None:
-        ordering = ordering[:max_sylls]
 
     # Get order mapping
     relabel_mapping = {o: i for i, o in enumerate(ordering)}


### PR DESCRIPTION
`.value_counts()` drops uuid-syllable pairs where there are no counts for that syllable. For downstream analyses, we should set the usages to 0 so we can get accurate means of the usages across mice/groups. 

I kept the durations and syllable means for these syllables as `NaN` with `features = usages.join(durations).join(features)`. I'm not sure if those `NaN`s will affect downsteam functions, but if so we can add in checks to remove null rows.