### PR TITLE
Behave dist fix

### DIFF
--- a/moseq2_viz/model/dist.py
+++ b/moseq2_viz/model/dist.py
@@ -62,7 +62,7 @@ def get_behavioral_distance(index, model_file, whiten='all',
                 max_syllable = lbl.max() + 1
 
     for dist in distances:
-        if 'ar' in dist.lower():
+        if 'ar[' in dist.lower():
 
             ar_mat = model_fit['model_parameters']['ar_mat']
             npcs = ar_mat[0].shape[0]


### PR DESCRIPTION
Fix `get_behavioral_distance` function. Currently will skip `scalars` distances because the `if 'ar' in dist.lower()` is not specific enough.

the substring `ar` exists in the string `scalars`!!