### PR TITLE
fix: `frame_path` parameter not passed to `make_crowd_matrix`

### DIFF
--- a/moseq2_viz/io/video.py
+++ b/moseq2_viz/io/video.py
@@ -164,6 +164,7 @@ def write_crowd_movies(sorted_index, config_data, ordering, labels, label_uuids,
                             raw_size=config_data.get('raw_size', (512, 424)),
                             scale=config_data.get('scale', 1),
                             pad=config_data.get('pad', 30),
+                            frame_path=config_data.get('frame_path', 'frames'),
                             legacy_jitter_fix=config_data.get('legacy_jitter_fix', False),
                             **clean_params)
 


### PR DESCRIPTION
Users were not able to create crowd movies using a different frame path in their h5 files because the `frame_path` parameter was not being passed into `make_crowd_matrix`.
- `frame_path` is a CLI parameter in the `make-crowd-movies` command, it is used to reference where the extracted crop-rotated frames in the h5 file.

## Issue being fixed or feature implemented
- Now passing a configurable `frame_path` parameter to the function `make_crowd_matrix()` in order to create the desired movie.

## How Has This Been Tested?
Local and Travis

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
