### PR TITLE
fix: `h5_to_dict()` silently fails when index file is missing pca_scores path

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -355,8 +355,8 @@ def get_syllable_slices(syllable, labels, label_uuids, index, trim_nans: bool = 
         try:
             score_idx = h5_to_dict(index['pca_path'], 'scores_idx')
         except OSError:
-            print('pca_path in index file is incorrectly set. Ensure the pca_path is pointing to the pca_scores.h5 file.')
-            trim_nans = False
+            raise OSError('pca_path in index file is incorrectly set. '
+                          'Ensure the pca_path is pointing to the pca_scores.h5 file.')
 
     syllable_slices = []
 


### PR DESCRIPTION
Users were not able to complete computing the `scalar_df` or `mean_df` if the `pca_scores` path was not correctly set in the index file. 

Issue being fixed or feature implemented
- Added a `try-except` to warn the users that the index file is missing the appropriate `pca_scores.h5` path.

How Has This Been Tested?
Local and Travis

Breaking Changes
None

Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
