### PR TITLE
fix+refactor: `compute_behavioral_statistics()` fails on `.rename()` if syllable column already exists

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -549,7 +549,14 @@ def compute_behavioral_statistics(scalar_df, groupby=['group', 'uuid'], count='u
     features = usages.join(durations).join(features)
     features['syllable key'] = syllable_key
 
-    return features.reset_index().rename(columns={syllable_key: 'syllable'})
+    try:
+        features = features.reset_index()
+    except ValueError:
+        # syllable_key already exists
+        features = features.drop(columns=[syllable_key]).reset_index()
+
+    # rename inputted column name to "syllable" for simpler column referencing.
+    return features.rename(columns={syllable_key: 'syllable'})
 
 
 def get_syllable_statistics(data, fill_value=-5, max_syllable=100, count='usage'):


### PR DESCRIPTION
`compute_behavioral_statistics()` fails when trying to rename a column title `'labels (usage sort)'` to `'syllable'`.

## Issue being fixed or feature implemented
- Safer handling of column renaming at the end of the function `compute_behavioral_statistics()`.
- Added function documentation to `compute_behavioral_statistics()`.

## How Has This Been Tested?
Local and Travis

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
