### PR TITLE
fix: Safer handling of sessions and `scalar_df` columns in `scalars_to_dataframe()`

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -429,11 +429,12 @@ def scalars_to_dataframe(index: dict, include_keys: list = ['SessionName', 'Subj
     '''
     warnings.filterwarnings('ignore', '', FutureWarning)
 
-    has_model = False
+    has_model = False # indicator for whether users inputted a model_path to load syllable labels from
     model_uuids = None
     if model_path is not None and exists(model_path):
         labels_df = prepare_model_dataframe(model_path, index['pca_path']).set_index('uuid')
         has_model = True
+        # loading the session uuids that the model was trained on
         model_uuids = labels_df.reset_index().uuid.unique()
 
     # check if files is dictionary from sorted_index or list from unsorted index, then sort
@@ -444,6 +445,7 @@ def scalars_to_dataframe(index: dict, include_keys: list = ['SessionName', 'Subj
     # Iterate through index file session info and paths
     for k, v in tqdm(index['files'].items(), disable=disable_output):
         if has_model:
+            # skipping the session uuids (found in the index file) that are not included in the model uuids.
             if k not in model_uuids:
                 continue
         # Get path to extraction h5 file


### PR DESCRIPTION
The `scalars_to_dataframe()` was not robust against inconsistencies within a given dataset. 
- For example, if a single session is missing an ROI variable, the operation fails.
- If a `model_path` is passed and a session's `uuid` is not included in the model, a pandas alignment issue will arise.
- If a session's metadata is malformed somehow, the operation may also be interrupted as well.

## Issue being fixed or feature implemented
- Function errors out if an `roi` key is missing from an h5 file.
- Skipping computing a session's scalar values if it was not modeled by the passed model in `model_path`.
- Handling metadata keys correctly such that they are correctly added to the `scalar_df`.
- Filtering out any incorrectly included keys.

## How Has This Been Tested?
Local and Travis

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
