### PR TITLE
fix: `compute_syllable_position_heatmaps` fails if syllable is not found

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -612,7 +612,11 @@ def compute_syllable_position_heatmaps(scalar_df, syllable_key='labels (usage so
 
     def _compute_histogram(df):
         df = df[centroid_keys].dropna(how='any')
-        H, _, _ = np.histogram2d(df.iloc[:, 1], df.iloc[:, 0], bins=bins, density=normalize)
+        try:
+            H, _, _ = np.histogram2d(df.iloc[:, 1], df.iloc[:, 0], bins=bins, density=normalize)
+        except KeyError:
+            # syllable not found in group
+            H = np.zeros((bins, bins))
         return H
 
     filtered_df = scalar_df[scalar_df[syllable_key].isin(syllables)]


### PR DESCRIPTION
## Issue being fixed or feature implemented
- `compute_syllable_position_heatmaps()` fails to compute if a syllable is not found in a session/group.

## How Has This Been Tested?
Travis and Local

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
