### PR TITLE
feat: plot syllable statistics with syllable labels and marked significant syllables

### DIFF
--- a/moseq2_viz/viz.py
+++ b/moseq2_viz/viz.py
@@ -460,7 +460,6 @@ def plot_syll_stats_with_sem(scalar_df, syll_info=None, sig_sylls=None, stat='us
                        join=join, dodge=True, ci=68, ax=ax, hue_order=groups,
                        palette=colors)
 
-    legend = ax.legend(frameon=False, bbox_to_anchor=(1, 1))
     # where some data has already been plotted to ax
     handles, labels = ax.get_legend_handles_labels()
 
@@ -472,6 +471,20 @@ def plot_syll_stats_with_sem(scalar_df, syll_info=None, sig_sylls=None, stat='us
 
         plt.xticks(range(max_sylls), mean_xlabels, rotation=90)
 
+    # if a list of significant syllables is given, mark the syllables above the x-axis
+    if sig_sylls is not None:
+        markings = []
+        for s in sig_sylls:
+            markings.append(ordering.index(s))
+        plt.scatter(markings, [-.005] * len(markings), color='r', marker='*')
+
+        # manually define a new patch
+        patch = mlines.Line2D([], [], color='red', marker='*', linestyle='None',
+                              markersize=9, label='Significant Syllable')
+        handles.append(patch)
+
+    # add legend and axis labels
+    legend = ax.legend(handles=handles, frameon=False, bbox_to_anchor=(1, 1))
     plt.xlabel(xlabel, fontsize=12)
     sns.despine()
 


### PR DESCRIPTION
<img src="https://drive.google.com/uc?export=view&id=1D0qXx1VHPdCkiWWQ05pwrm6HJFRgwjqM" width=700 height=400>

## Issue being fixed or feature implemented
- Users can now pass a `syll_info` dict object to plot the syllable labels in the x-axis along with the numbers.
- Users can now pass a list of integers `sig_sylls`, in order to mark the significant syllables on the x-axis.

## How Has This Been Tested?
Locally and Travis

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
