### PR TITLE
fix: Explained variance percentage doesn't go all the way to 100%

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -53,17 +53,15 @@ def compute_syllable_explained_variance(model, n_explained=99):
     '''
 
     syllable_usages = list(get_syllable_usages(model['labels'], count='usage').values())
-    cumulative_explanation = 100 * np.cumsum(syllable_usages / sum(syllable_usages))
-    # Syllables may not explain 100% of the variance due to rounding and precision
-    # Sufficient number of syllables may explain up to 99.99% of the variances
-    # We use 99.99% as an approximation for 100% explained variance percentage
-    cumulative_explanation += 0.0001
+    cumulative_explanation = np.cumsum(syllable_usages / sum(syllable_usages))
 
+    # Syllables may not explain 100% of the variance due to rounding and precision
+    # Normalized cumulative explained variance by max cumulative explained variance
+    cumulative_explanation = 100 * cumulative_explanation/np.max(cumulative_explanation)
     max_sylls = np.argwhere(cumulative_explanation >= n_explained)[0][0]
     print(f'Number of syllables explaining {n_explained}% variance: {max_sylls}')
 
     fig, ax = plt.subplots(1)
-
     ax.set_xlabel('Number of Syllables to Include')
     ax.set_ylabel('Explained Variance Percentage')
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
When users set `explained_variance` to 100, wanting to get the maximum number of syllable needed to explain 100% of the variance, there will be an error. The problem is caused by rounding and precision in `sum` and `np.cumsum`, such that the explained variance percentage could only go as high as 99.99%. The bug is fixed by adding 0.0001 to cumulative sum, such that 99.99% would be an approximation for 100%.
## How Has This Been Tested?
Tested in Travis CI  and locally on Jupyter Notebook
## Breaking Changes
No breaking changes
## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ]  I have added or updated relevant unit/integration/functional/e2e tests
- [ ]  I have made corresponding changes to the documentation