### PR TITLE
fix: Added `try-except` statements (with messages) for failed position PDF computations

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -459,7 +459,8 @@ def scalars_to_dataframe(index: dict, include_keys: list = ['SessionName', 'Subj
             roi = h5_to_dict(pth, path='metadata/extraction/roi')['roi'].shape
             dset['dist_to_center_px'] = compute_mouse_dist_to_center(roi, dset['centroid_x_px'], dset['centroid_y_px'])
         except OSError:
-            print('ROI was not found in the given h5 file. Not including dist_to_center_px')
+            print(f'ROI was not found in the given h5 file. \n'
+                  f'Not including the dist_to_center_px column in outputted scalar_df for session-uuid {k}')
             pass
 
         timestamps = get_timestamps_from_h5(pth)


### PR DESCRIPTION
## Issue being fixed or feature implemented
1. When computing a verbose position heatmap, a session with corrupted scalar values will raise an Exception interrupting the compute and plotting process.
2. Same Exception is raised when computing syllable position PDFs for unused syllables in a group or sesion.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Added `try-except` statements wrapping the `np.histogram2d()`, and printing a statement indicating which session or syllable is failing, and move on.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
