### PR TITLE
fix get_behavioral_distance()

### DIFF
--- a/moseq2_viz/model/dist.py
+++ b/moseq2_viz/model/dist.py
@@ -99,7 +99,7 @@ def get_behavioral_distance(index, model_file, whiten='all',
                 max_syllable = lbl.max() + 1
 
     for dist in distances:
-        if 'ar' in dist.lower():
+        if dist.lower() in ['ar[init]', 'ar[dtw]']:
 
             ar_mat = model_fit['model_parameters']['ar_mat']
             npcs = ar_mat[0].shape[0]


### PR DESCRIPTION
# Issue being fixed or feature implemented
`get_behavioral_distance()` would skip computing 'scalars' distances, because the substring `ar` is contained within the string "scal<ins>**ar**</ins>s". 

If passed `distances=['ar[init]', 'scalars']` only `'ar[init]'` distances would be returned.

If passed `distances=['scalars']` only `'ar[init]'` distances would be returned.

# How Has This Been Tested?
Locally + Travis

# What Was Done?
- Change the code to be more explicit for the value of `dist`, and avoid potential false-negatives from checking for the presence of a substring within `dist`.

# Breaking Changes
None

# Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation