### PR TITLE
Fix: get_syllable_slices() not returning slices in some cases

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -388,10 +388,18 @@ def get_syllable_slices(syllable, labels, label_uuids, index, trim_nans: bool = 
         match_idx = trim_idx[np.where(label_arr == syllable)[0]]
         breakpoints = np.where(np.diff(match_idx, axis=0) > 1)[0]
 
-        if len(breakpoints) < 1:
+        if len(match_idx) > 0 and len(breakpoints) < 1:
+            # CASE: if only one emission, breakpoints will be empty, since all diffs are 1
+            breakpoints = [(0, len(match_idx)-1)]
+
+        elif len(breakpoints) > 0:
+            # More than one emission in labels
+            breakpoints = zip(np.r_[0, breakpoints+1], np.r_[breakpoints, len(match_idx)-1])
+
+        else:
+            # Zero emissions found
             continue
 
-        breakpoints = zip(np.r_[0, breakpoints+1], np.r_[breakpoints, len(match_idx)-1])
         for i, j in breakpoints:
             # strike out movies that have missing frames
             if missing_frames is not None:


### PR DESCRIPTION
# Issue being fixed or feature implemented
`get_syllable_slices()` would fail to return slices if there was only one emission (one contiguous block of the same label) of the label within a given label array (single animal).

This is due to `np.diff` returning an array of all `1`s in this case, and `np.where` fails to find any "breakpoints", causing the loop to continue via the guarding `if`.

# How Has This Been Tested?
Locally + Travis

# What Was Done?
- Check for the case where we do have emissions of a label (via `len(match_idx)`) but no breakpoints were found. If so, construct proper breakpoints for the found emission. This is just a list containing a single tuple of `(0, len(match_idx)-1)`.

# Breaking Changes
None

# Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation

# Other Notes:
This is a "remake" of #117, but this branch is properly based on branch `dev` instead of `release`