### PR TITLE
fix: Replaced `try-except` statements in position-heatmap functions with concrete `if-else`s

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -541,8 +541,8 @@ def compute_all_pdf_data(scalar_df, normalize=False, centroid_vars=['centroid_x_
         subjectNames.append(_df[key].iat[0])
 
         pos = _df[centroid_vars].dropna(how='any')
-        if len(pos) > 1:
-            H, _, _ = np.histogram2d(pos.iloc[:, 1], pos.iloc[:, 0], bins=bins, density=normalize)
+        if len(pos) >= 1:
+            H, _, _ = np.histogram2d(np.array(pos.iloc[:, 1]), np.array(pos.iloc[:, 0]), bins=bins, density=normalize)
         else:
             print(f'Failed to generate position heatmap for session with uuid: {uuid}')
             H = np.zeros((bins, bins))
@@ -639,8 +639,8 @@ def compute_syllable_position_heatmaps(scalar_df, syllable_key='labels (usage so
     def _compute_histogram(df):
         centroid_df = df[centroid_keys].dropna(how='any')
 
-        if len(centroid_df) > 1:
-            H, _, _ = np.histogram2d(centroid_df.iloc[:, 1], centroid_df.iloc[:, 0], bins=bins, density=normalize)
+        if len(centroid_df) >= 1:
+            H, _, _ = np.histogram2d(np.array(centroid_df.iloc[:, 1]), np.array(centroid_df.iloc[:, 0]), bins=bins, density=normalize)
         else:
             # syllable not found in group
             print(f'Unable to generate position heatmap for syllable {df[syllable_key].to_numpy()}')

--- a/tests/unit_tests/test_scalar_utils.py
+++ b/tests/unit_tests/test_scalar_utils.py
@@ -242,6 +242,7 @@ class TestScalarUtils(TestCase):
         model_path = 'data/test_model.p'
 
         _, sorted_index = parse_index(test_index)
+        # deleting file key to "bad extraction example"
         del sorted_index['files']['ae8a9d45-7ad9-4048-963f-ca4931125fcd']
 
         scalar_df = scalars_to_dataframe(sorted_index, model_path=model_path)


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Issue described in #124; 
    - A `KeyError` is raised when `df` or `pos` sub-dfs have a length of <=1. Causing the `.iloc[:, 0]` operations to fail.
    - An `AttributeError` is raised from attempting to print `{df.syllable}`. 

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Replaced `try-except` statements with `if-else` depending on the length of the outputted sub-df.
- In `scalars.util.get_syllable_pdfs()`, using `np.nanmean` instead of `np.mean` just in case.
- Added base case unit test for `test_compute_syllable_position_heatmaps()`.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation