### PR TITLE
Fix closing pipe in write_frames_preview()

### DIFF
--- a/moseq2_viz/io/video.py
+++ b/moseq2_viz/io/video.py
@@ -293,7 +293,7 @@ def write_frames_preview(filename, frames=np.empty((0,)), threads=6,
         pipe.stdin.write(disp_img.astype('uint8').tostring())
 
     if close_pipe:
-        pipe.stdin.close()
+        pipe.communicate()
         return filename
     else:
         return pipe


### PR DESCRIPTION
# Issue being fixed or feature implemented
Discovered this bug on Windows, but may apply more silently on other systems.
The unit test `tests/unit_tests/test_io_video.py::TestIOVideo::test_write_frames_preview` failed on me with the error:
```
PermissionError: [WinError 32] The process cannot access the file because it is being used by another process: 'data/test_data2.avi'
```

Looking at the function `write_frames_preview`, you were calling `pipe.stdin.close()`, but this does not wait for the underlying `ffmpeg` process to finish, creating a race condition. In this case the call to `os.remove()` in the unit test was executing while ffmpeg still had a lock on the file, resulting in the `PermissionError`. Better to call `pipe.communicate()` which implicitly closes the `stdin` pipe, and then waits for the process to terminate.

# How Has This Been Tested?
Locally + Travis

# What Was Done?
- Swap out the call to `pipe.stdin.close()` with a call to `pipe.communicate()`

# Breaking Changes
None

# Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
