### PR TITLE
fix: `np.nanmean` raises ValueError in pandas `apply()` in get_syllable_pdfs()`

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -603,7 +603,7 @@ def get_syllable_pdfs(pdf_df, normalize=True, syllables=range(40), groupby='grou
 
     # Get unique groups to iterate by
     groups = pdf_df[groupby].unique()
-    mean_pdfs = pdf_df.groupby([groupby, syllable_key]).apply(np.nanmean)
+    mean_pdfs = pdf_df.groupby([groupby, syllable_key]).apply(np.mean)
 
     if normalize:
         mean_pdfs['pdf'] = mean_pdfs['pdf'].apply(lambda x: x / np.nanmax(x))


### PR DESCRIPTION
## Issue being fixed or feature implemented
- `np.nanmean` is not compatible with `pd.apply()`.
- Causes `ValueError` to be raised in `moseq2-app`.

![Screen Shot 2021-08-02 at 12 24 16 PM](https://user-images.githubusercontent.com/10673695/127893556-5972ea42-46cc-423c-bdf8-4841d44fdb24.png)

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Replaced call for `np.nanmean` -> `np.mean`.

## Breaking Changes
None

## Checklists
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
