### PR TITLE
fix: catching `ValueError` in `scalars_to_dataframe()` when `len(ts)!=len(frames)`

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -478,7 +478,14 @@ def scalars_to_dataframe(index: dict, include_keys: list = ['SessionName', 'Subj
                          key: v['metadata'][key] for key in include_keys if key in v['metadata'].keys()
                      })
 
-        _tmp_df = pd.DataFrame(dset)
+        try:
+            _tmp_df = pd.DataFrame(dset)
+        except ValueError as e:
+            print(f'Error in session with uuid: {k}')
+            print('Length of timestamps do not equal number of frames. Skipping this session.')
+            print(e.with_traceback())
+            continue
+
 
         # make sure we have labels for this UUID before merging
         if has_model and k in labels_df.index:


### PR DESCRIPTION
## Issue being fixed or feature implemented
- A `ValueError` is raised within the for-loop of `scalars.util.scalars_to_dataframe()` in cases where `len(timestamps) != len(frames)`.
    -  Known problems that cause this error:
        -  File organization mismatches
        - Acquisition computer does not have enough storage and starts dropping too many frames.

![Screen Shot 2021-08-04 at 5 16 05 PM](https://user-images.githubusercontent.com/10673695/128426412-89d98110-3abf-44f9-9107-96f267c4a10c.png)
![Screen Shot 2021-08-04 at 5 16 00 PM](https://user-images.githubusercontent.com/10673695/128426418-2a78fe9d-0e38-411f-b87c-fcdadc0586b3.png)

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Wrapped the casting of the dict object to a tmp `pd.DataFrame` with a `try-except`, indicating to users that the timestamps do not match the number of frames and that the session's scalars will not be computed.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
