### PR TITLE
fix: Added `AssertionError` if index file does not contain valid `pca_path`

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -813,6 +813,11 @@ def prepare_model_dataframe(model_path, pca_path):
     usage, _ = relabel_by_usage(labels, count='usage')
     frames, _ = relabel_by_usage(labels, count='frames')
 
+    if not os.path.isfile(pca_path):
+        raise AssertionError('The pca_path variable in the index file is not pointing to the correct file.\n'
+                             'Update the path in the index file to match the correct location of the '
+                             'pca_scores.h5 file that the model was trained with and run the command again.')
+
     scores_idx = h5_to_dict(pca_path, path='scores_idx')
 
     # make sure all pcs align with labels


### PR DESCRIPTION
## Issue being fixed or feature implemented
- If the index file does not contain the correct path to the `pca_scores.h5` file in the `pca_path` variable, an OSError is raised when attempting to parse a non-existent h5 file.

## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Added a condition to check whether the included path is a file, then raise an AssertionError with instructions on how to fix the problem.

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
