### PR TITLE
Fix: pytest test suites on MacOS leads to a foreverloop due to multiprocessing

### DIFF
--- a/tests/unit_tests/test_io_video.py
+++ b/tests/unit_tests/test_io_video.py
@@ -3,11 +3,14 @@ import shutil
 import joblib
 import numpy as np
 from glob import glob
+import multiprocessing as mp
 from unittest import TestCase
 from moseq2_viz.util import parse_index, read_yaml
 from moseq2_viz.model.util import parse_model_results, relabel_by_usage
 from moseq2_viz.io.video import write_crowd_movies, write_frames_preview, write_crowd_movie_info_file
 
+# Source: https://bugs.python.org/issue33725#msg329923
+mp.set_start_method('forkserver')
 
 class TestIOVideo(TestCase):
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
On MacOS, pytest runs into an infinite loop after running many video writing commands within the same test class. The bug was first detected in moseq2-app, described in https://github.com/dattalab/moseq2-app/issues/137.

## What was done?
Changed the `multiprocessing` context at the start of `test_io_video.py` as per [this forum comment](https://bugs.python.org/issue33725#msg329923).

The solution is from @aymanzay proposed in PR https://github.com/dattalab/moseq2-app/pull/139



## How Has This Been Tested?
Locally and Travis

## Breaking Changes
NA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
