### PR TITLE
fix: Spacing out model vs. pc changepoint info text in outputted figure

### DIFF
--- a/moseq2_viz/viz.py
+++ b/moseq2_viz/viz.py
@@ -637,11 +637,18 @@ def plot_cp_comparison(model_results, pc_cps, plot_all=False, best_model=None, b
         f'{np.nanmedian(pc_cps):.4f}, {mode(pc_cps)[0][0]:.4f}'
 
     # get figure maximum y-value
+    _, xmax = ax.get_xlim()
     _, ymax = ax.get_ylim()
 
     # space out the 2 plotted text glyphs
-    ax.text(0.5, ymax, s, fontsize=12)
-    ax.text(0.5, ymax - (ymax/5), t, fontsize=12)
+    ax.text(xmax, ymax, s,
+            horizontalalignment='right',
+            verticalalignment='top',
+            fontsize=12)
+    ax.text(xmax, ymax, t,
+            horizontalalignment='right',
+            verticalalignment='bottom',
+            fontsize=12)
 
     ax.set_xlabel('Block duration (s)')
     ax.set_ylabel('Probability density')


### PR DESCRIPTION
## Issue being fixed or feature implemented
- Hard coded plotted text coordinates sometimes causes the model and PC text information to overlap. (Depending on the y-axis maximum value)

Examples Below:

![download-14](https://user-images.githubusercontent.com/10673695/134707948-4d5c3b6a-fceb-4cc8-9b74-0ae5ebb8f270.png)

![download-9](https://user-images.githubusercontent.com/10673695/134707953-0903f8aa-95ba-431c-bba7-a4c826eab444.png)


## How Has This Been Tested?
Locally and Travis

## What Was Done?
- Replaced the hard coded text coordinates with dynamic xy-coordinate values that depend on the maximum xy-value of the plotted curves.
- Added `horizontalalignment` and `verticalalignment` parameters to `ax.text` for more consistent and precise text alignment, preventing overlaps or unnecessary large spacing between the 2 text glyphs.
- Reference [here](https://matplotlib.org/stable/gallery/text_labels_and_annotations/text_alignment.html)

## Breaking Changes
None

## Checklists
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
