### PR TITLE
feat!: handling analysis for multiple models

### DIFF
--- a/moseq2_viz/gui.py
+++ b/moseq2_viz/gui.py
@@ -144,7 +144,7 @@ def get_best_fit_model(progress_paths, output_file=None, plot_all=False, fps=30,
         output_file = join(progress_paths['plot_path'], 'model_vs_pc_changepoints')
 
     # Get paths to required parameters
-    model_dir = progress_paths['model_master_path']
+    model_dir = progress_paths['main_model_path']
     if not exists(progress_paths['changepoints_path']):
         changepoint_path = join(progress_paths['pca_dirname'], progress_paths['changepoints_path'] + '.h5')
     else:

--- a/tests/integration_tests/test_gui.py
+++ b/tests/integration_tests/test_gui.py
@@ -130,7 +130,7 @@ class TestGUI(TestCase):
         progress_paths = {
             'plot_path': 'data/gen_plots/',
             'model_session_path': 'data/models/',
-            'model_master_path': 'data/models/',
+            'main_model_path': 'data/models/',
             'pca_dirname': 'data/_pca/',
             'changepoints_path': 'changepoints'
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
Right now, all the models, crowd movies, and syllable info are in one folder, so changing the model name won't generate new crowd movies and new syllable info. Issue specified here https://github.com/dattalab/moseq2-app/issues/150

I added functionality to create a folder for each model to keep all the crowd movies and syllable info related to the movie. All the information will be saved with the model and switching models won't wipe crowd movies and syllable info related to models.

Related to https://github.com/dattalab/moseq2-app/pull/169

## What was done?
I added 'model_master_path' to save the path that has all the models, and that path is used in get_best_fit_model.


## How Has This Been Tested?
Locally and CI


## Breaking Changes
get_best_fit_model in moseq2_viz/gui.py now check all the models in progress_paths['model_master_path'] instead.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
