### PR TITLE
feat: raise exception when there is no pca score file in moseq2-index.yaml

### DIFF
--- a/moseq2_viz/util.py
+++ b/moseq2_viz/util.py
@@ -268,6 +268,8 @@ def parse_index(index: Union[str, dict]) -> tuple:
     else:
         sorted_index = valmap(lambda d: assoc(d, 'path', tuple(d['path'])), sorted_index)
 
+    if index['pca_path'] is None:
+        raise Exception("Please add pac_score path to moseq2-index.yaml")
     uuid_sorted = {
         'files': sorted_index,
         'pca_path': join(index_dir, index['pca_path']) if not from_dict else index['pca_path']


### PR DESCRIPTION
## Issue being fixed or feature implemented
moseq2-index.yaml is not used during pca score step in the CLI so pca_path is not added to moseq2-index.yaml file, causing visualization such as `moseq2-viz plot-stats` to fail. If users use the interactive analysis notebook instead of the CLI, the pc_score would be added to the moseq2-index.yaml. In CLI since in viz, config file is not used, so pc score can't be added to moseq2-index.yaml file automatically.

https://github.com/dattalab/moseq2-app/issues/189

## What was done?
Added exception to tell users to specify pc score.


## How Has This Been Tested?
CI and locally.

## Breaking Changes
NA



## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
