### PR TITLE
chore: update links in download scripts

### DIFF
--- a/scripts/download_test_data.sh
+++ b/scripts/download_test_data.sh
@@ -1,2 +1,2 @@
-curl -L -o data.zip https://www.dropbox.com/sh/u5rr91fe15t7vpt/AAC_ysh-XbXanZDS4XXMcBEva?dl=0 && unzip data.zip -d data
+curl -L -o data.zip https://www.dropbox.com/sh/oxfgp2s7sn3x8ur/AABFcyMi4JO5hvTMVUDYbRuDa?dl=0 && unzip data.zip -d data
 rm data.zip


### PR DESCRIPTION
## Issue being fixed or feature implemented
Update links to download test data since Ayman's dropbox links will no longer be available.