### PR TITLE
chore!: main_model_path to base_model_path

### DIFF
--- a/moseq2_viz/gui.py
+++ b/moseq2_viz/gui.py
@@ -144,7 +144,7 @@ def get_best_fit_model(progress_paths, output_file=None, plot_all=False, fps=30,
         output_file = join(progress_paths['plot_path'], 'model_vs_pc_changepoints')
 
     # Get paths to required parameters
-    model_dir = progress_paths['main_model_path']
+    model_dir = progress_paths['base_model_path']
     if not exists(progress_paths['changepoints_path']):
         changepoint_path = join(progress_paths['pca_dirname'], progress_paths['changepoints_path'] + '.h5')
     else:

--- a/tests/integration_tests/test_gui.py
+++ b/tests/integration_tests/test_gui.py
@@ -130,7 +130,7 @@ class TestGUI(TestCase):
         progress_paths = {
             'plot_path': 'data/gen_plots/',
             'model_session_path': 'data/models/',
-            'main_model_path': 'data/models/',
+            'base_model_path': 'data/models/',
             'pca_dirname': 'data/_pca/',
             'changepoints_path': 'changepoints'
         }


### PR DESCRIPTION
## Issue being fixed or feature implemented
I changed main_model_path to base_model_path


## What was done?
I changed main_model_path to base_model_path


## How Has This Been Tested?
Locally and CI

## Breaking Changes
main_model_path is now called base_model_path, moseq2-model, moseq2-viz, moseq2-app are the repos that are affected.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
