### PR TITLE
feat: clipping changepoints at 10s for get-best-fit

### DIFF
--- a/moseq2_viz/viz.py
+++ b/moseq2_viz/viz.py
@@ -653,6 +653,7 @@ def plot_cp_comparison(model_results, pc_cps, plot_all=False, best_model=None, b
     kappa = _mdl['model_parameters']['kappa']
 
     if not plot_all and best_model is not None:
+        # clipping the changepoints at 10 seconds
         ax = sns.kdeplot(model_cps[model_cps<10], ax=ax, color='blue', label=f'Model Changepoints Kappa={kappa:1.02E}',
                          bw_adjust=bw_adjust)
     else:
@@ -665,6 +666,7 @@ def plot_cp_comparison(model_results, pc_cps, plot_all=False, best_model=None, b
 
             kappa = v['model_parameters']['kappa']
             model_cps = v['changepoints']
+            # clipping the changepoints at 10 seconds
             ax = sns.kdeplot(model_cps[model_cps<10], ax=ax, linestyle=ls, alpha=alpha, bw_adjust=bw_adjust,
                         color=palette[i], label=f'Model Changepoints Kappa={kappa:1.02E}')
     # Format plot


### PR DESCRIPTION
## Issue being fixed or feature implemented
Clipping the changepoints at 10s to avoid misleading plots for get best model fit.


## What was done?
clipping both models at 10 second for plotting


## How Has This Been Tested?
CI and local

## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
