### PR TITLE
fix: delete incorrect error message print statement

### DIFF
--- a/moseq2_viz/scalars/util.py
+++ b/moseq2_viz/scalars/util.py
@@ -481,6 +481,7 @@ def scalars_to_dataframe(index: dict, include_keys: list = ['SessionName', 'Subj
         except ValueError as e:
             print(f'Error in session with uuid: {k}')
             print('Length of timestamps do not equal number of frames. Skipping this session.')
+            print(e)
             continue
 
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
with_traceback() is incorrectly called and the message is not necessary for the widget. i deleted the print statement.


## What was done?
Deleting error with_traceback print statement


## How Has This Been Tested?
Locally and CI


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
