### PR TITLE
fix: create figure folder in case it doesn't exist

### DIFF
--- a/moseq2_viz/model/fingerprint_classifier.py
+++ b/moseq2_viz/model/fingerprint_classifier.py
@@ -17,6 +17,7 @@ from sklearn.base import clone
 import pandas as pd
 import numpy as np
 from os.path import join
+from os import makedirs
 
 
 def robust_min(v):
@@ -195,6 +196,7 @@ def plotting_fingerprint(summary, save_dir, range_dict, preprocessor=None, num_l
         cb.set_xlabel('Percentage Usage')
 
     # saving the figure
+    makedirs(save_dir, exist_ok=True)
     fig.savefig(join(save_dir, 'moseq_fingerprint.pdf'))
     fig.savefig(join(save_dir, 'moseq_fingerprint.png'))
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
save fingerprint will error if the figure folder hasn't been created


## What was done?
added a line to make sure it exists


## How Has This Been Tested?
CI and locally


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
