### PR TITLE
fix: setting groups in config_data or CLI won't change tm graphs

### DIFF
--- a/moseq2_viz/helpers/wrappers.py
+++ b/moseq2_viz/helpers/wrappers.py
@@ -369,7 +369,11 @@ def plot_transition_graph_wrapper(index_file, model_fit, output_file, config_dat
 
     # Get modeled session uuids to compute group-mean transition graph for
     label_group, _ = get_trans_graph_groups(model_data)
-    group = list(set(label_group))
+    
+    if config_data.get('group') is not None:
+        group = list(config_data.get('group'))
+    else:
+        group = list(set(label_group))
 
     print('Computing transition matrices...')
     try:


### PR DESCRIPTION
## Issue being fixed or feature implemented
the group option in moseq2-viz plot-transition-graph is not implemented correctly and all groups will be plotted, regardless of the input options.


## What was done?
added if-else statement to include user specified groups.


## How Has This Been Tested?
locally & CI


## Breaking Changes
NA

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation
