### PR TITLE
fix: incorrect usage thresholding causing syllable 0 to drop

### DIFF
--- a/moseq2_viz/model/trans_graph.py
+++ b/moseq2_viz/model/trans_graph.py
@@ -86,6 +86,7 @@ def compute_and_graph_grouped_TMs(config_data, labels, label_group, group):
     plt (pyplot.Figure): open transition graph figure to save
     '''
 
+    trans_mats, usages = get_group_trans_mats(labels, label_group, sorted(group), config_data['max_syllable'], config_data['normalize'])
 
     # Option to not scale node sizes proportional to the syllable usage.
     if not config_data['scale_node_by_usage']:
@@ -303,12 +304,14 @@ def convert_transition_matrix_to_ebunch(weights, transition_matrix,
         ebunch = list(filter(lambda e: e[:-1] in indices, ebunch))
 
     def _filter_by_stat(arg, stat, stat_threshold):
+        from math import ceil, floor
         _in, _out, _ = arg
         _in = stat[_in]
         _out = stat[_out]
         if isinstance(stat_threshold, (list, tuple)):
-            return ((_in > stat_threshold[0] and _in < stat_threshold[1])
-                    and (_out > stat_threshold[0] and _out < stat_threshold[1]))
+            # round down the lower bound and round up the upper bound to 1000th decimal
+            return ((_in > floor(stat_threshold[0]*1000)/1000. and _in <= ceil(stat_threshold[1]*1000)/1000.)
+                    and (_out >= floor(stat_threshold[0]*1000)/1000. and _out <= ceil(stat_threshold[1]*1000)/1000.))
         return _in > stat_threshold and _out > stat_threshold
 
     if usages is not None:


### PR DESCRIPTION
## Issue being fixed or feature implemented
usage threshold is not implemented correctly, causing syllable 0 to be missing from time to time in the interactive transition graphs.

Thank you for helping us find the bug @jingliulj 
## What was done?
changed the threshold to reflect the usages after normalization 

## How Has This Been Tested?
locally on test dataset and ci

## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
