### PR TITLE
fix: re-order sigma when relabel by usage

### DIFF
--- a/moseq2_viz/model/util.py
+++ b/moseq2_viz/model/util.py
@@ -827,10 +827,13 @@ def parse_model_results(model_obj, restart_idx=0, resample_idx=-1,
 
     if sort_labels_by_usage:
         output_dict['labels'], sorting = relabel_by_usage(output_dict['labels'], count=count)
+        # reorder the ar matrix and sigma
         old_ar_mat = deepcopy(output_dict['model_parameters']['ar_mat'])
+        old_sig = deepcopy(output_dict['model_parameters']['sig'])
         old_nu = deepcopy(output_dict['model_parameters']['nu'])
         for i, sort_idx in enumerate(sorting):
             output_dict['model_parameters']['ar_mat'][i] = old_ar_mat[sort_idx]
+            output_dict['model_parameters']['sig'][i] = old_sig[sort_idx]
             if isinstance(output_dict['model_parameters']['nu'], list):
                 output_dict['model_parameters']['nu'][i] = old_nu[sort_idx]
 


### PR DESCRIPTION
## Issue being fixed or feature implemented
https://github.com/dattalab/moseq2-viz/issues/171


## What was done?
re-ordered sigma

## How Has This Been Tested?
locally


## Breaking Changes
NA


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added or updated relevant unit/integration/functional/e2e tests
- [ ] I have made corresponding changes to the documentation
